### PR TITLE
feat: add CLI installation guide to landing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0"
       },
@@ -17049,6 +17050,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0"
   },

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -533,3 +533,106 @@
 .codeExample {
   margin-top: 2rem;
 }
+
+/* CLI Download Tabs */
+.cliDownload {
+  margin-top: 1rem;
+}
+
+.tabsContainer {
+  display: flex;
+  border-bottom: 2px solid var(--ifm-color-emphasis-200);
+  margin-bottom: 1rem;
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--ifm-color-emphasis-600);
+  border-bottom: 2px solid transparent;
+  transition: all 0.2s ease;
+  position: relative;
+}
+
+.tab:hover {
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-emphasis-800);
+}
+
+.tabActive {
+  color: var(--ifm-font-color-secondary) !important;
+  border-bottom-color: var(--ifm-color-primary);
+}
+
+.tabIcon {
+  font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+}
+
+/* Dark theme adjustments */
+[data-theme="dark"] .tab:hover {
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-100);
+}
+
+[data-theme="dark"] .tabActive {
+  background: rgba(181, 208, 85, 0.1);
+}
+
+/* Code container with copy button */
+.codeContainer {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+.copyButton {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background: var(--ifm-color-emphasis-200);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  padding: 0.5rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+}
+
+.copyButton:hover {
+  background: var(--ifm-color-emphasis-300);
+  color: var(--ifm-color-emphasis-800);
+  transform: scale(1.05);
+}
+
+.copyButtonSuccess {
+  background: var(--ifm-color-success) !important;
+  color: white !important;
+  border-color: var(--ifm-color-success) !important;
+}
+
+/* Dark theme copy button adjustments */
+[data-theme="dark"] .copyButton {
+  background: var(--ifm-color-emphasis-300);
+  border-color: var(--ifm-color-emphasis-400);
+  color: var(--ifm-color-emphasis-100);
+}
+
+[data-theme="dark"] .copyButton:hover {
+  background: var(--ifm-color-emphasis-400);
+  color: var(--ifm-color-emphasis-0);
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,11 @@
 import type { ReactNode } from "react";
+import { useState, useEffect } from "react";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import Heading from "@theme/Heading";
+import { FaApple, FaLinux, FaCopy, FaCheck } from "react-icons/fa";
 
 import styles from "./index.module.css";
 
@@ -95,6 +97,106 @@ function FeatureSection() {
   );
 }
 
+function CliDownloadTabs() {
+  // Function to detect the user's operating system
+  const detectOS = (): "macos" | "linux" => {
+    if (typeof window === "undefined") {
+      // Server-side rendering fallback
+      return "linux";
+    }
+
+    const userAgent = window.navigator.userAgent.toLowerCase();
+    const platform = window.navigator.platform?.toLowerCase() || "";
+
+    // Check for macOS/iOS
+    if (
+      userAgent.includes("mac") ||
+      platform.includes("mac") ||
+      userAgent.includes("iphone") ||
+      userAgent.includes("ipad")
+    ) {
+      return "macos";
+    }
+
+    // Default to Linux for everything else (Linux, Windows users can still switch)
+    return "linux";
+  };
+
+  const [activeTab, setActiveTab] = useState<"macos" | "linux">("linux");
+  const [copied, setCopied] = useState(false);
+
+  // Set the correct tab based on detected OS when component mounts
+  useEffect(() => {
+    setActiveTab(detectOS());
+  }, []);
+
+  const commands = {
+    macos: `INSTALL_DIR="/usr/local/bin" sh <(curl -L https://raw.githubusercontent.com/EnclaveRunner/cli/main/install.sh)`,
+    linux: `INSTALL_DIR="~/.local/bin" sh <(curl -L https://raw.githubusercontent.com/EnclaveRunner/cli/main/install.sh)`,
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(commands[activeTab]);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000); // Reset after 2 seconds
+    } catch (err) {
+      // Fallback for older browsers
+      const textArea = document.createElement('textarea');
+      textArea.value = commands[activeTab];
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <div className={styles.cliDownload}>
+      <div className={styles.tabsContainer}>
+        <button
+          className={clsx(
+            styles.tab,
+            activeTab === "macos" && styles.tabActive
+          )}
+          onClick={() => setActiveTab("macos")}
+        >
+          <span className={styles.tabIcon}>
+            <FaApple />
+          </span>
+          macOS
+        </button>
+        <button
+          className={clsx(
+            styles.tab,
+            activeTab === "linux" && styles.tabActive
+          )}
+          onClick={() => setActiveTab("linux")}
+        >
+          <span className={styles.tabIcon}>
+            <FaLinux />
+          </span>
+          Linux
+        </button>
+      </div>
+      <div className={styles.codeContainer}>
+        <pre className={styles.codeBlock}>
+          <code>{commands[activeTab]}</code>
+        </pre>
+        <button
+          className={clsx(styles.copyButton, copied && styles.copyButtonSuccess)}
+          onClick={handleCopy}
+          title={copied ? "Copied!" : "Copy to clipboard"}
+        >
+          {copied ? <FaCheck /> : <FaCopy />}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function GetStartedSection() {
   return (
     <section className={styles.getStarted}>
@@ -103,8 +205,10 @@ function GetStartedSection() {
           <div className="col col--6">
             <h2>Quick Start</h2>
             <p>
-              Get up and running with EnclaveRunner in minutes using docker
-              compose or deploy it to your Kubernetes cluster (planned).
+              You already have a running instance of EnclaveRunner and want to
+              get started? Get the encl CLI to deploy your first isolated job in
+              minutes! If you haven't set up an EnclaveRunner instance yet,
+              check out the First Steps section.
             </p>
             <div className={styles.quickStartLinks}>
               <Link
@@ -123,10 +227,8 @@ function GetStartedSection() {
           </div>
           <div className="col col--6">
             <div className={styles.codeExample}>
-              <h3>Example Usage</h3>
-              <pre className={styles.codeBlock}>
-                <code>{`<coming soon>`}</code>
-              </pre>
+              <h3>Download and install the encl CLI</h3>
+              <CliDownloadTabs />
             </div>
           </div>
         </div>


### PR DESCRIPTION
# Description
Simple installation guide on how to install the cli, the os of the client is detected and the according installation guide is shown first (please test this with you linux system @habetuz )

<img width="1724" height="372" alt="image" src="https://github.com/user-attachments/assets/26402ce0-9891-496e-a88e-b56dcc6a4004" />
